### PR TITLE
Added intro, combining intro + overview

### DIFF
--- a/collections/proxima-safe/proxima-overview.md
+++ b/collections/proxima-safe/proxima-overview.md
@@ -15,6 +15,29 @@ sidebar:
     - url: https://developer.oracle.com/proximasafe-part-3/
       title: Proxima Safe Part 3
 ---
+
+## Welcome to ProximaSafe, an evolution of Smart Cities!
+
+Wait, what on Earth is Proxima and why is it Safe? 
+
+Great questions. 
+
+In 2018, Oracle developed ProximaCity, a physical product showcasing how cloud services can optimize the resource-intensive processes which make communities functional. This was an exciting outgrowth of Oracle's [Smart City](https://www.oracle.com/industries/public-sector/smart-cities/) initiative. It was a big hit.
+
+Then there was a pandemic. 
+
+ProximaCity needed to adapt from a sprawling physical model to something more streamlined. Optimization was still a priority, but safety came first. 
+
+Enter ProximaSafe. 
+
+ProximaSafe extends the goals of the old ProximaCity, but uses data to proactively defend against biological threats (monitoring environmental parameters and ensuring sanitation stations, for example).
+
+### What to expect from this series
+
+This series walks you through creating a personal development lab which you can build at home, or just read to follow along. The theme of the lab, its use cases and sample data, borrows from the COVID pandemic. Using APIs, edge components, and sensors, you'll use OCI services to build safety-related use cases.
+
+The goal here is to enable teachers, students, developers, and tinkerers to use and improve this "portable lab" and develop new safety-oriented use cases to explore and expand its necessary back-end cloud services.
+
 ## The Briefcase Dream
 
 I've always been a fan of Marvel superheroes comics, long before the successful movie franchise known as MCU. Actually, around 1972–1975, I could find several Marvel comics carefully translated and lettered in my native language by visiting my friendly (actually, he wasn't) news vendor, strategically placed in the market street corner few hundred yards from where I lived.


### PR DESCRIPTION
So instead of cloning the repo and adding a sub-module to the collections directory, or adding a new card within the Proxima collection, I just chose the path of least resistance and added the introduction to this overview. I figure we can adjust this later, but the intro needs to be live by tomorrow, so I'm thinking the important thing for now is just that it's in there.